### PR TITLE
Feature/enable mvvm bindings

### DIFF
--- a/examples/WPFLocalizationExtensionDemoApplication.sln
+++ b/examples/WPFLocalizationExtensionDemoApplication.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFLocalizationExtensionDem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFLocalizationExtensionDemoTexts", "WPFLocalizationExtensionDemoTexts\WPFLocalizationExtensionDemoTexts.csproj", "{ED4F118B-4A5B-4D5B-BCB7-62A5DC280AA8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WPFLocalizeExtension", "..\src\WPFLocalizeExtension.csproj", "{ED1805DE-4E8B-418A-A43C-023511C4D005}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{ED4F118B-4A5B-4D5B-BCB7-62A5DC280AA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED4F118B-4A5B-4D5B-BCB7-62A5DC280AA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED4F118B-4A5B-4D5B-BCB7-62A5DC280AA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED1805DE-4E8B-418A-A43C-023511C4D005}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED1805DE-4E8B-418A-A43C-023511C4D005}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED1805DE-4E8B-418A-A43C-023511C4D005}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED1805DE-4E8B-418A-A43C-023511C4D005}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/examples/WPFLocalizationExtensionDemoApplication/App.xaml
+++ b/examples/WPFLocalizationExtensionDemoApplication/App.xaml
@@ -1,8 +1,8 @@
 ﻿<Application x:Class="WPFLocalizationExtensionDemoApplication.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:WPFLocalizationExtensionDemoApplication"
-             xmlns:infrastructure="clr-namespace:WPFLocalizationExtensionDemoApplication.Infrastructure">
+             xmlns:infrastructure="clr-namespace:WPFLocalizationExtensionDemoApplication.Infrastructure"
+             xmlns:local="clr-namespace:WPFLocalizationExtensionDemoApplication">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/examples/WPFLocalizationExtensionDemoApplication/ViewModels/Examples/TextLocalizationExampleViewModel.cs
+++ b/examples/WPFLocalizationExtensionDemoApplication/ViewModels/Examples/TextLocalizationExampleViewModel.cs
@@ -1,17 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Caliburn.Micro;
+﻿using Caliburn.Micro;
 
 namespace WPFLocalizationExtensionDemoApplication.ViewModels.Examples
 {
     public class TextLocalizationExampleViewModel : Screen
     {
+        private string _resourceKey;
+
         public TextLocalizationExampleViewModel()
         {
-            base.DisplayName = "TextLocalizationExample";
+            base.DisplayName = ResourceKey = "TextLocalizationExample";
+        }
+
+        public string ResourceKey
+        {
+            get { return _resourceKey; }
+            set
+            {
+                if (value == _resourceKey) return;
+                _resourceKey = value;
+                NotifyOfPropertyChange(() => ResourceKey);
+            }
         }
     }
 }

--- a/examples/WPFLocalizationExtensionDemoApplication/ViewModels/Examples/TextLocalizationExampleViewModel.cs
+++ b/examples/WPFLocalizationExtensionDemoApplication/ViewModels/Examples/TextLocalizationExampleViewModel.cs
@@ -1,28 +1,65 @@
 ﻿using Caliburn.Micro;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 using WPFLocalizeExtension;
+using WPFLocalizeExtension.Extensions;
+using WPFLocalizeExtension.Providers;
 
 namespace WPFLocalizationExtensionDemoApplication.ViewModels.Examples
 {
-    public class TextLocalizationExampleViewModel : Screen
+    public class TextLocalizationExampleViewModel : Screen, INotifyPropertyChanged
     {
         private string _resourceKey;
+
+        private string _resourceText;
 
         public TextLocalizationExampleViewModel()
         {
             base.DisplayName = ResourceKey = "TextLocalizationExample";
+
+            BindPropertyToResource(nameof(ResourceText), "TextLocalizationExample2");
         }
+
+        public event PropertyChangedEventHandler PropertyChanged;
 
         public string ResourceKey
         {
             get { return _resourceKey; }
             set
             {
-                if (value == _resourceKey) return;
+                if (value == _resourceKey)
+                    return;
                 _resourceKey = value;
-                NotifyOfPropertyChange(() => ResourceKey);
+                OnPropertyChanged();
             }
         }
 
         public ResourceKeyViewModel ResourceKeyVM { get; set; } = new ResourceKeyViewModel("TextLocalizationExample");
+
+        public string ResourceText
+        {
+            get { return _resourceText; }
+            set
+            {
+                if (value == _resourceText) return;
+                _resourceText = value;
+                OnPropertyChanged();
+            }
+        }
+
+        protected void BindPropertyToResource(string propertyName, string resourceKey)
+        {
+            var resxLocalizationProvider = ResxLocalizationProvider.Instance;
+
+            var targetProperty = GetType().GetProperty(propertyName);
+            var locBinding = new LocTextExtension(resourceKey);
+
+            locBinding.SetBinding(this, targetProperty);
+        }
+
+        protected virtual void OnPropertyChanged([CallerMemberName]string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
     }
 }

--- a/examples/WPFLocalizationExtensionDemoApplication/ViewModels/Examples/TextLocalizationExampleViewModel.cs
+++ b/examples/WPFLocalizationExtensionDemoApplication/ViewModels/Examples/TextLocalizationExampleViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Caliburn.Micro;
+using WPFLocalizeExtension;
 
 namespace WPFLocalizationExtensionDemoApplication.ViewModels.Examples
 {
@@ -21,5 +22,7 @@ namespace WPFLocalizationExtensionDemoApplication.ViewModels.Examples
                 NotifyOfPropertyChange(() => ResourceKey);
             }
         }
+
+        public ResourceKeyViewModel ResourceKeyVM { get; set; } = new ResourceKeyViewModel("TextLocalizationExample");
     }
 }

--- a/examples/WPFLocalizationExtensionDemoApplication/ViewModels/MainViewModel.cs
+++ b/examples/WPFLocalizationExtensionDemoApplication/ViewModels/MainViewModel.cs
@@ -7,7 +7,7 @@ namespace WPFLocalizationExtensionDemoApplication.ViewModels
     {
         public MainViewModel()
         {
-            //this.Items.Add(new GapTextWpfExampleViewModel());
+            Items.Add(new GapTextWpfExampleViewModel());
             Items.Add(new TextLocalizationExampleViewModel());
         }
     }

--- a/examples/WPFLocalizationExtensionDemoApplication/ViewModels/MainViewModel.cs
+++ b/examples/WPFLocalizationExtensionDemoApplication/ViewModels/MainViewModel.cs
@@ -7,8 +7,8 @@ namespace WPFLocalizationExtensionDemoApplication.ViewModels
     {
         public MainViewModel()
         {
-            this.Items.Add(new GapTextWpfExampleViewModel());
-            this.Items.Add(new TextLocalizationExampleViewModel());
+            //this.Items.Add(new GapTextWpfExampleViewModel());
+            Items.Add(new TextLocalizationExampleViewModel());
         }
     }
 }

--- a/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
+++ b/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
@@ -1,54 +1,69 @@
 ﻿<UserControl x:Class="WPFLocalizationExtensionDemoApplication.Views.Examples.TextLocalizationExampleView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:local="clr-namespace:WPFLocalizationExtensionDemoApplication.Views.Examples"
-             xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
              xmlns:examples="clr-namespace:WPFLocalizationExtensionDemoApplication.ViewModels.Examples"
+             xmlns:lex="http://wpflocalizeextension.codeplex.com"
+             xmlns:local="clr-namespace:WPFLocalizationExtensionDemoApplication.Views.Examples"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             Name="me"
+             Width="800"
+             Height="450"
+             d:DataContext="{d:DesignInstance {x:Type examples:TextLocalizationExampleViewModel}}"
              lex:LocalizeDictionary.DesignCulture="en"
              lex:ResxLocalizationProvider.DefaultAssembly="WPFLocalizationExtensionDemoTexts"
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
-    xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
-             mc:Ignorable="d"
-             d:DataContext="{d:DesignInstance {x:Type examples:TextLocalizationExampleViewModel}}"
-             Height="450" Width="800"
-             Name="me">
+             mc:Ignorable="d">
     <UserControl.Resources>
         <lex:TranslateConverter x:Key="TranslateConverter" />
 
-        <Style TargetType="TextBlock" x:Key="hardCodedStyle">
+        <Style x:Key="hardCodedStyle"
+               TargetType="TextBlock">
             <Setter Property="Text" Value="{lex:BLoc TextLocalizationExample}" />
         </Style>
 
-        <Style TargetType="TextBlock" x:Key="bindingStyle">
+        <Style x:Key="bindingStyle"
+               TargetType="TextBlock">
             <Setter Property="Text" Value="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />
         </Style>
 
-        <Style TargetType="TextBlock" x:Key="updatableBindingStyle">
+        <Style x:Key="updatableBindingStyle"
+               TargetType="TextBlock">
             <Setter Property="Text" Value="{Binding ResourceKeyVM.ResourceKey, Converter={StaticResource TranslateConverter}}" />
         </Style>
     </UserControl.Resources>
     <StackPanel>
-        <!--Normal static localization using a hard coded resource key in xaml -->
+        <!--  Normal static localization using a hard coded resource key in xaml  -->
         <TextBlock Text="{lex:Loc TextLocalizationExample}" />
 
-        <!--Normal static localization using a hard coded resource key in xaml style -->
+        <!--  Normal static localization using a hard coded resource key in xaml style  -->
         <TextBlock Text="{lex:BLoc TextLocalizationExample}" />
         <TextBlock Style="{StaticResource hardCodedStyle}" />
 
-        <!--Normal WPF Binding to ViewModel -->
-        <TextBox Text="{Binding ResourceKey, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock Margin="5"
+                   FontWeight="Bold">
+            Localization using a key provided by WPF Binding to ViewModel.
+        </TextBlock>
 
-        <!--Localization using a key provided by WPF Binding to ViewModel -->
-        <!-- Supports automatic refresh on language switching, but cannot be applied in a style -->
+        <TextBox Text="{Binding ResourceKey, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock Margin="5"
+                   FontWeight="Bold">
+            Supports automatic refresh on language switching, but cannot be applied in a style.
+        </TextBlock>
         <TextBlock Text="{lex:BindingLoc {Binding ResourceKey}}" />
 
-        <!-- No support of automatic refresh on language switching, but can be applied in a style -->
+        <TextBlock Margin="5"
+                   FontWeight="Bold">
+            No support of automatic refresh on language switching, but can be applied in a style.
+        </TextBlock>
         <TextBlock Text="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />
         <TextBlock Style="{StaticResource bindingStyle}" />
 
-        <!--Normal WPF Binding to ViewModel -->
+        <TextBlock Margin="5"
+                   FontWeight="Bold">
+            Supports automatic refresh on language switching AND can be applied in a style, but is rather much code.
+        </TextBlock>
         <TextBox Text="{Binding ResourceKeyVM.ResourceKey, UpdateSourceTrigger=PropertyChanged}" />
         <TextBlock Text="{Binding ResourceKeyVM.ResourceKey, Converter={StaticResource TranslateConverter}}" />
         <TextBlock Style="{StaticResource updatableBindingStyle}" />

--- a/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
+++ b/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
@@ -9,32 +9,39 @@
              lex:LocalizeDictionary.DesignCulture="en"
              lex:ResxLocalizationProvider.DefaultAssembly="WPFLocalizationExtensionDemoTexts"
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
+    xmlns:diag="clr-namespace:System.Diagnostics;assembly=WindowsBase"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance {x:Type examples:TextLocalizationExampleViewModel}}"
              Height="450" Width="800"
              Name="me">
     <UserControl.Resources>
         <lex:TranslateConverter x:Key="TranslateConverter" />
-        <Style TargetType="TextBlock" x:Key="localizedText">
-            <Setter Property="Text" Value="{lex:BindingLoc {Binding ResourceKey}}" />
+
+        <Style TargetType="TextBlock" x:Key="hardCodedStyle">
+            <Setter Property="Text" Value="{lex:BLoc TextLocalizationExample}" />
+        </Style>
+
+        <Style TargetType="TextBlock" x:Key="bindingStyle">
+            <Setter Property="Text" Value="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />
         </Style>
     </UserControl.Resources>
     <StackPanel>
         <!--Normal static localization using a hard coded resource key in xaml -->
-        <!--<TextBlock Text="{lex:Loc TextLocalizationExample}" />-->
-        <!--<TextBlock Text="{lex:BLoc TextLocalizationExample}" />-->
-        <!--<TextBlock Text="{lex:BindingLoc {Binding ResourceKey}}" />-->
+        <TextBlock Text="{lex:Loc TextLocalizationExample}" />
 
-        <TextBlock Style="{StaticResource localizedText}" />
+        <!--Normal static localization using a hard coded resource key in xaml style -->
+        <TextBlock Text="{lex:BLoc TextLocalizationExample}" />
+        <TextBlock Style="{StaticResource hardCodedStyle}" />
 
         <!--Normal WPF Binding to ViewModel -->
         <TextBox Text="{Binding ResourceKey, UpdateSourceTrigger=PropertyChanged}" />
 
         <!--Localization using a key provided by WPF Binding to ViewModel -->
-        <!--<lex:LocProxy Name="LocProxy" Source="{Binding ResourceKey}" />
-        <TextBlock Text="{Binding ElementName=LocProxy, Path=Result}" />-->
+        <!-- Supports automatic refresh on language switching, but cannot be applied in a style -->
+        <TextBlock Text="{lex:BindingLoc {Binding ResourceKey}}" />
 
-        <!--Localization using TranslateConverter -->
-        <!--<TextBlock Text="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />-->
+        <!-- No support of automatic refresh on language switching, but can be applied in a style -->
+        <TextBlock Text="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />
+        <TextBlock Style="{StaticResource bindingStyle}" />
     </StackPanel>
 </UserControl>

--- a/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
+++ b/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
@@ -15,12 +15,17 @@
              Name="me">
     <UserControl.Resources>
         <lex:TranslateConverter x:Key="TranslateConverter" />
+        <Style TargetType="TextBlock" x:Key="localizedText">
+            <Setter Property="Text" Value="{lex:BindingLoc {Binding ResourceKey}}" />
+        </Style>
     </UserControl.Resources>
     <StackPanel>
         <!--Normal static localization using a hard coded resource key in xaml -->
         <!--<TextBlock Text="{lex:Loc TextLocalizationExample}" />-->
         <!--<TextBlock Text="{lex:BLoc TextLocalizationExample}" />-->
-        <TextBlock Text="{lex:BindingLoc {Binding ResourceKey}}" />
+        <!--<TextBlock Text="{lex:BindingLoc {Binding ResourceKey}}" />-->
+
+        <TextBlock Style="{StaticResource localizedText}" />
 
         <!--Normal WPF Binding to ViewModel -->
         <TextBox Text="{Binding ResourceKey, UpdateSourceTrigger=PropertyChanged}" />

--- a/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
+++ b/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
@@ -24,6 +24,10 @@
         <Style TargetType="TextBlock" x:Key="bindingStyle">
             <Setter Property="Text" Value="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />
         </Style>
+
+        <Style TargetType="TextBlock" x:Key="updatableBindingStyle">
+            <Setter Property="Text" Value="{Binding ResourceKeyVM.ResourceKey, Converter={StaticResource TranslateConverter}}" />
+        </Style>
     </UserControl.Resources>
     <StackPanel>
         <!--Normal static localization using a hard coded resource key in xaml -->
@@ -43,5 +47,10 @@
         <!-- No support of automatic refresh on language switching, but can be applied in a style -->
         <TextBlock Text="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />
         <TextBlock Style="{StaticResource bindingStyle}" />
+
+        <!--Normal WPF Binding to ViewModel -->
+        <TextBox Text="{Binding ResourceKeyVM.ResourceKey, UpdateSourceTrigger=PropertyChanged}" />
+        <TextBlock Text="{Binding ResourceKeyVM.ResourceKey, Converter={StaticResource TranslateConverter}}" />
+        <TextBlock Style="{StaticResource updatableBindingStyle}" />
     </StackPanel>
 </UserControl>

--- a/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
+++ b/examples/WPFLocalizationExtensionDemoApplication/Views/Examples/TextLocalizationExampleView.xaml
@@ -11,17 +11,25 @@
              lex:ResxLocalizationProvider.DefaultDictionary="Strings"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance {x:Type examples:TextLocalizationExampleViewModel}}"
-             d:DesignHeight="450" d:DesignWidth="800"
+             Height="450" Width="800"
              Name="me">
+    <UserControl.Resources>
+        <lex:TranslateConverter x:Key="TranslateConverter" />
+    </UserControl.Resources>
     <StackPanel>
         <!--Normal static localization using a hard coded resource key in xaml -->
-        <TextBlock Text="{lex:Loc TextLocalizationExample}" />
+        <!--<TextBlock Text="{lex:Loc TextLocalizationExample}" />-->
+        <!--<TextBlock Text="{lex:BLoc TextLocalizationExample}" />-->
+        <TextBlock Text="{lex:BindingLoc {Binding ResourceKey}}" />
 
         <!--Normal WPF Binding to ViewModel -->
-        <TextBlock Text="{Binding DisplayName}" />
+        <TextBox Text="{Binding ResourceKey, UpdateSourceTrigger=PropertyChanged}" />
 
         <!--Localization using a key provided by WPF Binding to ViewModel -->
-        <lex:LocProxy Name="LocProxy" Source="{Binding DisplayName}" />
-        <TextBlock Text="{Binding ElementName=LocProxy, Path=Result}" />
+        <!--<lex:LocProxy Name="LocProxy" Source="{Binding ResourceKey}" />
+        <TextBlock Text="{Binding ElementName=LocProxy, Path=Result}" />-->
+
+        <!--Localization using TranslateConverter -->
+        <!--<TextBlock Text="{Binding ResourceKey, Converter={StaticResource TranslateConverter}}" />-->
     </StackPanel>
 </UserControl>

--- a/examples/WPFLocalizationExtensionDemoApplication/WPFLocalizationExtensionDemoApplication.csproj
+++ b/examples/WPFLocalizationExtensionDemoApplication/WPFLocalizationExtensionDemoApplication.csproj
@@ -36,23 +36,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Caliburn.Micro, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
-      <HintPath>packages\Caliburn.Micro.Core.3.2.0\lib\net45\Caliburn.Micro.dll</HintPath>
-    </Reference>
-    <Reference Include="Caliburn.Micro.Platform, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
-      <HintPath>packages\Caliburn.Micro.3.2.0\lib\net45\Caliburn.Micro.Platform.dll</HintPath>
-    </Reference>
-    <Reference Include="Caliburn.Micro.Platform.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=8e5891231f2ed21f, processorArchitecture=MSIL">
-      <HintPath>packages\Caliburn.Micro.3.2.0\lib\net45\Caliburn.Micro.Platform.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>packages\Caliburn.Micro.3.2.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -65,12 +53,6 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WPFLocalizeExtension, Version=3.3.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\WPFLocalizeExtension.3.3.1\lib\net452\WPFLocalizeExtension.dll</HintPath>
-    </Reference>
-    <Reference Include="XAMLMarkupExtensions, Version=1.5.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\XAMLMarkupExtensions.1.5.1\lib\net452\XAMLMarkupExtensions.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">
@@ -127,7 +109,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -141,10 +122,19 @@
     <Folder Include="Converters\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\WPFLocalizeExtension.csproj">
+      <Project>{ed1805de-4e8b-418a-a43c-023511c4d005}</Project>
+      <Name>WPFLocalizeExtension</Name>
+    </ProjectReference>
     <ProjectReference Include="..\WPFLocalizationExtensionDemoTexts\WPFLocalizationExtensionDemoTexts.csproj">
       <Project>{ed4f118b-4a5b-4d5b-bcb7-62a5dc280aa8}</Project>
       <Name>WPFLocalizationExtensionDemoTexts</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Caliburn.Micro">
+      <Version>3.2.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/examples/WPFLocalizationExtensionDemoApplication/packages.config
+++ b/examples/WPFLocalizationExtensionDemoApplication/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Caliburn.Micro" version="3.2.0" targetFramework="net452" />
-  <package id="Caliburn.Micro.Core" version="3.2.0" targetFramework="net452" />
-  <package id="WPFLocalizeExtension" version="3.3.1" targetFramework="net452" />
-  <package id="XAMLMarkupExtensions" version="1.5.1" targetFramework="net452" />
-</packages>

--- a/examples/WPFLocalizationExtensionDemoTexts/Strings.Designer.cs
+++ b/examples/WPFLocalizationExtensionDemoTexts/Strings.Designer.cs
@@ -187,6 +187,15 @@ namespace WPFLocalizationExtensionDemoTexts {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to this is different.
+        /// </summary>
+        internal static string TextLocalizationExample2 {
+            get {
+                return ResourceManager.GetString("TextLocalizationExample2", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Language:.
         /// </summary>
         internal static string Toolbar_LanguageLabel {

--- a/examples/WPFLocalizationExtensionDemoTexts/Strings.de.resx
+++ b/examples/WPFLocalizationExtensionDemoTexts/Strings.de.resx
@@ -165,4 +165,7 @@
   <data name="TextLocalizationExample" xml:space="preserve">
     <value>TextLocalizationExample de</value>
   </data>
+  <data name="TextLocalizationExample2" xml:space="preserve">
+    <value>das ist anders</value>
+  </data>
 </root>

--- a/examples/WPFLocalizationExtensionDemoTexts/Strings.resx
+++ b/examples/WPFLocalizationExtensionDemoTexts/Strings.resx
@@ -165,4 +165,7 @@
   <data name="TextLocalizationExample" xml:space="preserve">
     <value>TextLocalizationExample en</value>
   </data>
+  <data name="TextLocalizationExample2" xml:space="preserve">
+    <value>this is different</value>
+  </data>
 </root>

--- a/src/Extensions/BindingLoc.cs
+++ b/src/Extensions/BindingLoc.cs
@@ -7,9 +7,13 @@ using WPFLocalizeExtension.Engine;
 namespace WPFLocalizeExtension.Extensions
 {
     /// <summary>
-    /// Applies the given <see cref="Binding"/> to the related <see cref="DependencyProperty"/>.
+    /// Use this class if you have the ResourcesKey in a property of a ViewModel and want it to be translated in your view.
+    /// Supports automatic refresh on language switching or if the bound ResourceKey changes.
+    /// ATTENTION: <see cref="MarkupExtension"/>s are not usable within a WPF style.
+    /// <code>
+    ///     <TextBlock Text = "{lex:BindingLoc {Binding ResourceKey}}" />
+    /// </code>
     /// </summary>
-    /// <remarks><see cref="MarkupExtension"/>s are not usable within a WPF style.</remarks>
     public class BindingLoc : MarkupExtension, IDictionaryEventListener
     {
         private readonly Binding _binding;
@@ -20,6 +24,9 @@ namespace WPFLocalizeExtension.Extensions
 
         private DependencyProperty _targetProp;
 
+        /// <summary>
+        /// Applies the given <see cref="Binding"/> to the related <see cref="DependencyProperty"/>.
+        /// </summary>
         public BindingLoc(Binding binding)
         {
             _binding = binding;

--- a/src/Extensions/BindingLoc.cs
+++ b/src/Extensions/BindingLoc.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Markup;
+using WPFLocalizeExtension.Engine;
+
+namespace WPFLocalizeExtension.Extensions
+{
+    public class BindingLoc : MarkupExtension, IDictionaryEventListener
+    {
+        private static BindingLoc test;
+
+        private readonly Binding _binding;
+
+        private BindingExpression _bindingExpression;
+
+        private FrameworkElement _target;
+
+        private DependencyProperty _targetProp;
+
+        public BindingLoc(Binding binding)
+        {
+            test = this;
+
+            _binding = binding;
+            _binding.Converter = new TranslateConverter();
+
+            LocalizeDictionary.DictionaryEvent.AddListener(this);
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            if (_bindingExpression == null)
+            {
+                if (serviceProvider.GetService(typeof(IProvideValueTarget)) is IProvideValueTarget pvt)
+                {
+                    _target = pvt?.TargetObject as FrameworkElement;
+                    _targetProp = pvt.TargetProperty as DependencyProperty;
+                }
+            }
+
+            return _binding.ProvideValue(serviceProvider);
+        }
+
+        public void ResourceChanged(DependencyObject sender, DictionaryEventArgs e)
+        {
+            if (_bindingExpression == null)
+            {
+                _bindingExpression = _target.GetBindingExpression(_targetProp);
+            }
+
+            _bindingExpression.UpdateTarget();
+        }
+    }
+}

--- a/src/Extensions/BindingLoc.cs
+++ b/src/Extensions/BindingLoc.cs
@@ -24,8 +24,12 @@ namespace WPFLocalizeExtension.Extensions
         {
             _binding = binding;
             _binding.Converter = new TranslateConverter();
-            _binding.ConverterParameter = this; // Stops garbage collection of this instance in order to receive events from LocalizeDictionary
 
+            // Stops garbage collection of this instance in order to receive events from LocalizeDictionary
+            // Once, the binding is gone, this instance should be garbage collected.
+            _binding.ConverterParameter = this;
+
+            // do not need to remove listener, for LocalizeDictionary keeps weak references
             LocalizeDictionary.DictionaryEvent.AddListener(this);
         }
 

--- a/src/Extensions/TranslateConverter.cs
+++ b/src/Extensions/TranslateConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Windows.Data;
+using WPFLocalizeExtension.Engine;
 
 namespace WPFLocalizeExtension.Extensions
 {
@@ -11,7 +12,10 @@ namespace WPFLocalizeExtension.Extensions
             if (value == null)
                 return null;
 
-            return LocExtension.GetLocalizedValue<string>(value.ToString());
+            if (LocalizeDictionary.Instance.GetIsInDesignMode())
+                return $"Key: {value}";
+            else
+                return LocExtension.GetLocalizedValue<string>(value.ToString());
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Extensions/TranslateConverter.cs
+++ b/src/Extensions/TranslateConverter.cs
@@ -5,6 +5,9 @@ using WPFLocalizeExtension.Engine;
 
 namespace WPFLocalizeExtension.Extensions
 {
+    /// <summary>
+    /// Takes given value as resource key and translates it. If no text is found, the received value is returned.
+    /// </summary>
     public class TranslateConverter : IValueConverter
     {
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
@@ -15,7 +18,7 @@ namespace WPFLocalizeExtension.Extensions
             if (LocalizeDictionary.Instance.GetIsInDesignMode())
                 return $"Key: {value}";
             else
-                return LocExtension.GetLocalizedValue<string>(value.ToString());
+                return LocExtension.GetLocalizedValue<string>(value.ToString()) ?? value;
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/src/Extensions/TranslateConverter.cs
+++ b/src/Extensions/TranslateConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace WPFLocalizeExtension.Extensions
+{
+    public class TranslateConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return null;
+
+            return LocExtension.GetLocalizedValue<string>(value.ToString());
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/ResourceKeyViewModel.cs
+++ b/src/ResourceKeyViewModel.cs
@@ -1,0 +1,54 @@
+﻿using System.ComponentModel;
+using System.Windows;
+using WPFLocalizeExtension.Engine;
+
+namespace WPFLocalizeExtension
+{
+    /// <summary>
+    /// Wrapper around a string that raises <see cref="INotifyPropertyChanged"/>
+    /// when the language changes or when the <see cref="ResourceKey"/> changes.
+    /// </summary>
+    public class ResourceKeyViewModel : IDictionaryEventListener, INotifyPropertyChanged
+    {
+        private static PropertyChangedEventArgs ResourceKeyEventArgs = new PropertyChangedEventArgs(nameof(ResourceKey));
+
+        public ResourceKeyViewModel(string resourceKey)
+        {
+            ResourceKey = resourceKey;
+
+            // do not need to remove listener, for LocalizeDictionary keeps weak references
+            LocalizeDictionary.DictionaryEvent.AddListener(this);
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private string _resourceKey;
+
+        public string ResourceKey
+        {
+            get { return _resourceKey; }
+            set
+            {
+                if (_resourceKey != value)
+                {
+                    _resourceKey = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public void ResourceChanged(DependencyObject sender, DictionaryEventArgs e)
+        {
+            RaisePropertyChanged();
+        }
+
+        /// <summary>
+        /// Notify that a property has changed
+        /// </summary>
+        /// <param name="property">The property that changed</param>
+        private void RaisePropertyChanged()
+        {
+            PropertyChanged?.Invoke(this, ResourceKeyEventArgs);
+        }
+    }
+}

--- a/src/ResourceKeyViewModel.cs
+++ b/src/ResourceKeyViewModel.cs
@@ -5,12 +5,14 @@ using WPFLocalizeExtension.Engine;
 namespace WPFLocalizeExtension
 {
     /// <summary>
-    /// Wrapper around a string that raises <see cref="INotifyPropertyChanged"/>
+    /// Wrappers a <see cref="ResourceKey"/>-string that raises <see cref="INotifyPropertyChanged"/>
     /// when the language changes or when the <see cref="ResourceKey"/> changes.
     /// </summary>
     public class ResourceKeyViewModel : IDictionaryEventListener, INotifyPropertyChanged
     {
         private static PropertyChangedEventArgs ResourceKeyEventArgs = new PropertyChangedEventArgs(nameof(ResourceKey));
+
+        private string _resourceKey;
 
         public ResourceKeyViewModel(string resourceKey)
         {
@@ -21,8 +23,6 @@ namespace WPFLocalizeExtension
         }
 
         public event PropertyChangedEventHandler PropertyChanged;
-
-        private string _resourceKey;
 
         public string ResourceKey
         {


### PR DESCRIPTION
https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/issues/117

I've introduced 

- BindingLoc which works fine as long as you do not want to set it in a style
- TranslateConverter + ResourceKeyViewModel which is not as compfortable, but also working in a style

I'va extended the demo application to show how it can be used