### PR TITLE
fix InheritingResx checks in LocDic

### DIFF
--- a/src/Engine/LocalizeDictionary.cs
+++ b/src/Engine/LocalizeDictionary.cs
@@ -792,7 +792,7 @@ namespace WPFLocalizeExtension.Engine
         /// <returns>The value corresponding to the source/dictionary/key path for the given culture (otherwise NULL).</returns>
         public object GetLocalizedObject(string key, DependencyObject target, CultureInfo culture)
         {
-            if (DefaultProvider is InheritingResxLocalizationProvider)
+            if (DefaultProvider is IInheritingLocalizationProvider)
                 return GetLocalizedObject(key, target, culture, DefaultProvider);
 
             var provider = target?.GetValue(GetProvider);
@@ -827,7 +827,7 @@ namespace WPFLocalizeExtension.Engine
         /// <returns>Returns an object with all possible pieces of the given key (Assembly, Dictionary, Key)</returns>
         public FullyQualifiedResourceKeyBase GetFullyQualifiedResourceKey(string key, DependencyObject target)
         {
-            if (DefaultProvider is InheritingResxLocalizationProvider)
+            if (DefaultProvider is IInheritingLocalizationProvider)
                 return GetFullyQualifiedResourceKey(key, target, DefaultProvider);
 
             var provider = target?.GetValue(GetProvider);

--- a/src/Extensions/LocExtension.cs
+++ b/src/Extensions/LocExtension.cs
@@ -332,7 +332,7 @@ namespace WPFLocalizeExtension.Extensions
 
             foreach (var dObj in targetDOs)
             {
-                if (LocalizeDictionary.Instance.DefaultProvider is InheritingResxLocalizationProvider)
+                if (LocalizeDictionary.Instance.DefaultProvider is IInheritingLocalizationProvider)
                 {
                     UpdateNewValue();
                     break;

--- a/src/Providers/IInheritingLocalizationProvider.cs
+++ b/src/Providers/IInheritingLocalizationProvider.cs
@@ -1,0 +1,25 @@
+﻿#region Copyright information
+// <copyright file="ILocalizationProvider.cs">
+//     Licensed under Microsoft Public License (Ms-PL)
+//     https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/blob/master/LICENSE
+// </copyright>
+// <author>Uwe Mayer</author>
+#endregion
+
+namespace WPFLocalizeExtension.Providers
+{
+    #region Usings
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using System.Windows;
+    #endregion
+
+    /// <summary>
+    /// An interface describing classes that provide localized values based on a source/dictionary/key combination.
+    /// and used for a localization provider that uses Inheriting Dependency Properties
+    /// </summary>
+    public interface IInheritingLocalizationProvider: ILocalizationProvider
+    {
+    
+    }
+}

--- a/tests/AssemblyTest/MainWindow.xaml
+++ b/tests/AssemblyTest/MainWindow.xaml
@@ -19,7 +19,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" Height="479" Width="329"
 
    
-    lex:LocalizeDictionary.DefaultProvider="{x:Static lex:InheritingResxLocalizationProvider.Instance}"
+        lex:LocalizeDictionary.DefaultProvider="{x:Static lex:InheritingResxLocalizationProvider.Instance}"
         lex:InheritingResxLocalizationProvider.DefaultAssembly="AssemblyTestResourceLib"
         lex:InheritingResxLocalizationProvider.DefaultDictionary="Strings">
     <!--Use this syntax to set the inheriting provider-->


### PR DESCRIPTION
closes #229 - remove direct cast for InheritingResx Provider in LocDic and replaced by a check for an Interface.

