### PR TITLE
StringFormatConverter: fixed and added unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Example.xlsx
 packages/
 .vs/
 *.nupkg
+
+# Jetbrain Rider Cache
+.idea/ 

--- a/src/ValueConverters/StringFormatConverter.cs
+++ b/src/ValueConverters/StringFormatConverter.cs
@@ -10,12 +10,8 @@ namespace WPFLocalizeExtension.ValueConverters
 {
     #region Usings
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Reflection;
-    using System.Text;
-    using System.Threading.Tasks;
     using System.Windows;
     using System.Windows.Data;
     #endregion
@@ -47,10 +43,10 @@ namespace WPFLocalizeExtension.ValueConverters
                 }
             }
 
-            if (targetType != typeof(string))
-                throw new Exception("Only string as targettype is allowed");
+            if (!targetType.IsAssignableFrom(typeof(string)))
+                throw new Exception("TargetType is not supported strings");
 
-            if (values == null | values.Length < 1)
+            if (values == null || values.Length < 1)
                 throw new Exception("Not enough parameters");
 
             if (values[0] == null)

--- a/src/ValueConverters/StringFormatConverter.cs
+++ b/src/ValueConverters/StringFormatConverter.cs
@@ -11,7 +11,6 @@ namespace WPFLocalizeExtension.ValueConverters
     #region Usings
     using System;
     using System.Globalization;
-    using System.Reflection;
     using System.Windows;
     using System.Windows.Data;
     #endregion
@@ -21,28 +20,10 @@ namespace WPFLocalizeExtension.ValueConverters
     /// </summary>
     public class StringFormatConverter : TypeValueConverterBase, IMultiValueConverter
     {
-        private static MethodInfo miFormat = null;
-
         #region IMultiValueConverter
         /// <inheritdoc/>
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            if (miFormat == null)
-            {
-                try
-                {
-                    // try to load SmartFormat Assembly
-                    var asSmartFormat = Assembly.Load("SmartFormat");
-                    var tt = asSmartFormat.GetType("SmartFormat.Smart");
-                    miFormat = tt.GetMethod("Format", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(object) }, null);
-                }
-                catch
-                {
-                    // fallback just take String.Format
-                    miFormat = typeof(string).GetMethod("Format", BindingFlags.Static | BindingFlags.Public, null, new Type[] { typeof(string), typeof(object) }, null);
-                }
-            }
-
             if (!targetType.IsAssignableFrom(typeof(string)))
                 throw new Exception("TargetType is not supported strings");
 
@@ -55,7 +36,13 @@ namespace WPFLocalizeExtension.ValueConverters
             if (values.Length > 1 && values[1] == DependencyProperty.UnsetValue)
                 return null;
 
-            return (string)miFormat.Invoke(null, values);
+            var format = values[0].ToString();
+            if (values.Length == 1)
+                return format;
+
+            var args = new object[values.Length - 1];
+            Array.Copy(values, 1, args, 0, args.Length);
+            return string.Format(format, args);
         }
 
         /// <inheritdoc/>

--- a/tests/Tests.sln
+++ b/tests/Tests.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFLocalizeExtension", "..\src\WPFLocalizeExtension.csproj", "{4A1CC23E-BA4A-4AC8-89CF-E29E0547EAEC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFLocalizeExtension.UnitTests", "WPFLocalizeExtension.UnitTests\WPFLocalizeExtension.UnitTests.csproj", "{93C35807-8585-43E3-BA53-15A7B811828E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4A1CC23E-BA4A-4AC8-89CF-E29E0547EAEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A1CC23E-BA4A-4AC8-89CF-E29E0547EAEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A1CC23E-BA4A-4AC8-89CF-E29E0547EAEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A1CC23E-BA4A-4AC8-89CF-E29E0547EAEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93C35807-8585-43E3-BA53-15A7B811828E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93C35807-8585-43E3-BA53-15A7B811828E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93C35807-8585-43E3-BA53-15A7B811828E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93C35807-8585-43E3-BA53-15A7B811828E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/WPFLocalizeExtension.UnitTests/ValueConvertersTests/StringFormatConverterTests.cs
+++ b/tests/WPFLocalizeExtension.UnitTests/ValueConvertersTests/StringFormatConverterTests.cs
@@ -1,0 +1,162 @@
+﻿namespace WPFLocalizeExtension.UnitTests.ValueConvertersTests
+{
+    #region Usings
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Text;
+    using System.Windows;
+    using Xunit;
+    using WPFLocalizeExtension.ValueConverters;
+    #endregion
+    
+    /// <summary>
+    /// Tests for converter <see cref="StringFormatConverter" />.
+    /// </summary>
+    public class StringFormatConverterTests
+    {
+        private const string CONVERTED_VALUE = "hello world";
+        private readonly object[] _values = new object[] { "{0} {1}", "hello", "world" };
+        
+        /// <summary>
+        /// Test data for <see cref="Convert_SpecifiedValues_ValueConverted" />.
+        /// </summary>
+        public static IReadOnlyList<object[]> ExpectedStringAndValuesData =>
+            new List<object[]>
+            {
+                new object[] { "hello world", "{0} {1}", "hello", "world" },
+                new object[] { "12345", "{0}{1}{2}{3}{4}", 1, 2, 3, 4, 5 },
+                new object[] { "hello world", "hello world" },
+                new object[] { "01.01.1970", "{0:dd.MM.yyyy}", new DateTime(1970, 1, 1, 10, 0, 0) },
+                new object[] { "hello world", new StringBuilder("{0} {1}"), "hello", "world" },
+            };
+        
+        /// <summary>
+        /// Check that converter is supported <see cref="object" /> and <see cref="string" /> as target type.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(object))]
+        [InlineData(typeof(string))]
+        public void Convert_SupportedTargetType_ValueConverted(Type targetType)
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT.
+            var convertedValue = converter.Convert(_values, targetType, null, CultureInfo.InvariantCulture);
+            
+            // ASSERT.
+            Assert.Equal(CONVERTED_VALUE, convertedValue);
+        }
+        
+        /// <summary>
+        /// Check that converter is not supported target types others except <see cref="object" /> and <see cref="string" />.
+        /// </summary>
+        [Theory]
+        [InlineData(typeof(int))]
+        [InlineData(typeof(DateTime))]
+        [InlineData(typeof(StringBuilder))]
+        public void Convert_UnsupportableTargetTypes_ExceptionThrown(Type targetType)
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT + ASSERT.
+            var exception = Assert.Throws<Exception>(() => converter.Convert(_values, targetType, null, CultureInfo.InvariantCulture));
+            Assert.Equal("TargetType is not supported strings", exception.Message);
+        }
+
+        /// <summary>
+        /// Check that exception is thrown if passed null as values parameter.
+        /// </summary>
+        [Fact]
+        public void Convert_ValuesIsNull_ExceptionThrown()
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT + ASSERT.
+            var exception = Assert.Throws<Exception>(() => converter.Convert(null, typeof(string), null, CultureInfo.InvariantCulture));
+            Assert.Equal("Not enough parameters", exception.Message);
+        }
+        
+        /// <summary>
+        /// Check that exception is thrown if passed empty array as values parameter.
+        /// </summary>
+        [Fact]
+        public void Convert_ValuesIsEmpty_ExceptionThrown()
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT + ASSERT.
+            var exception = Assert.Throws<Exception>(() => converter.Convert(Array.Empty<object>(), typeof(string), null, CultureInfo.InvariantCulture));
+            Assert.Equal("Not enough parameters", exception.Message);
+        }
+        
+        /// <summary>
+        /// Check that returns null if passed null format string.
+        /// </summary>
+        [Fact]
+        public void Convert_FormatStringIsNull_ReturnsNull()
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT.
+            var convertedValue = converter.Convert(new object[] { null, "hello", "world" }, typeof(string), null, CultureInfo.InvariantCulture);
+            
+            // ASSERT.
+            Assert.Null(convertedValue);
+        }
+        
+        /// <summary>
+        /// Check that returns null if passed UnsetValue as second value.
+        /// </summary>
+        [Fact]
+        public void Convert_SecondValueIsUnsetValue_ReturnsNull()
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT.
+            var convertedValue = converter.Convert(new[] { CONVERTED_VALUE, DependencyProperty.UnsetValue }, typeof(string), null, CultureInfo.InvariantCulture);
+            
+            // ASSERT.
+            Assert.Null(convertedValue);
+        }
+        
+        /// <summary>
+        /// Check different combinations of input values.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(ExpectedStringAndValuesData))]
+        public void Convert_SpecifiedValues_ValueConverted(string expectedConvertedValue, params object[] values)
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT.
+            var convertedValue = converter.Convert(values, typeof(string), null, CultureInfo.InvariantCulture);
+            
+            // ASSERT.
+            Assert.Equal(expectedConvertedValue, convertedValue);
+        }
+
+        /// <summary>
+        /// Check that ConvertBack just return null value without throw exceptions.
+        /// </summary>
+        [Fact]
+        public void ConvertBack_AnyValue_ReturnsNull()
+        {
+            // ARRANGE.
+            var converter = new StringFormatConverter();
+            
+            // ACT.
+            var originalValues = converter.ConvertBack(CONVERTED_VALUE, new []{ typeof(string) }, null, CultureInfo.InvariantCulture);
+            
+            // ASSERT.
+            Assert.Null(originalValues);
+        }
+    }
+}

--- a/tests/WPFLocalizeExtension.UnitTests/WPFLocalizeExtension.UnitTests.csproj
+++ b/tests/WPFLocalizeExtension.UnitTests/WPFLocalizeExtension.UnitTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+
+        <IsPackable>false</IsPackable>
+
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+        <PackageReference Include="xunit" Version="2.4.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+        <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\WPFLocalizeExtension.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Based on PR #280 and also related to #279 

* Add supporting of `object` target type
* Fixed `|` instead `||`
* Removed dynamic invocation
* Created unit tests for `StringFormatConverter`
* Added gitignore for Rider IDE